### PR TITLE
💄 Adaptation responsive du chevron pour plier/déplier les UE, Ressources et SAÉs.

### DIFF
--- a/html/assets/styles/releve-but-custom.css
+++ b/html/assets/styles/releve-but-custom.css
@@ -16,6 +16,10 @@ main{
 .sae .module{
 	color: #1e1e1e;
 }
+.sae .module::before {
+    /* Passer le glyphe SVG du blanc au noir en utilisant le filtre inverser */
+    filter: invert(1);
+}
 .eval:hover, .syntheseModule:hover{
     color: #FFF;
 }

--- a/html/assets/styles/releve-but.css
+++ b/html/assets/styles/releve-but.css
@@ -205,15 +205,21 @@ section>div:nth-child(1){
 	position: relative;
 }
 .module::before, .ue::before {
-	content:url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='26px' height='26px' fill='black'><path d='M7.41,8.58L12,13.17L16.59,8.58L18,10L12,16L6,10L7.41,8.58Z' /></svg>");
+	content:url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='26px' height='26px' fill='white'><path d='M7.41,8.58L12,13.17L16.59,8.58L18,10L12,16L6,10L7.41,8.58Z' /></svg>");
 	width: 26px;
 	height: 26px;
 	position: absolute;
 	bottom: 0;
-	left: 50%;
-	margin-left: -13px;
+	left: calc(50% - 13px);
 	transform: rotate(180deg);
 	transition: 0.2s;
+}
+@media screen and (max-width: 1000px) {
+    /* Placer le chevron à gauche au lieu du milieu */
+    .module::before, .ue::before {
+        left: 2px;
+        bottom: calc(50% - 13px);
+    }
 }
 h3{
     display: flex;


### PR DESCRIPTION
Au-delà, inversion de la couleur pour la classe `.sae` pour correspondre au texte en noir sur le fond jaune.

https://user-images.githubusercontent.com/20224422/149676273-96c38607-3320-431b-bddb-712c90ff132d.mp4

![Démonstration des couleurs adaptées dans chaque contexte](https://user-images.githubusercontent.com/20224422/149676291-28446d64-563d-4c8a-93d3-4bc8b73a7bc9.png)

Il est à noter que même en définissant la largeur d'activation à 1000px (la même que pour celle qui déploie le menu sur le côté), certaines SAÉ avec de long titres (du moins pour le BUT MMI) ont toujours le comportement précédent, à savoir le texte qui occulte le chveron.