### PR TITLE
Fix: affichage si pas de groupes (démissionnaires).

### DIFF
--- a/html/assets/js/releve-but.js
+++ b/html/assets/js/releve-but.js
@@ -227,7 +227,8 @@ class releveBUT extends HTMLElement {
 				<div>Min. promo. :</div><div>${data.semestre.notes.min}</div>
 			</div>
 			${(()=>{
-				if(Object.keys(data.semestre.rang.groupes).length == 0){
+				((!data.semestre.rang.groupes) ||
+					(Object.keys(data.semestre.rang.groupes).length == 0)){
 					return "";
 				}
 				let output = "";


### PR DESCRIPTION

Avec certains réglages (et étudiant démissionnaire), `data.semestre.rang.groupes` peut être `null` et le code d'affichage plante.