### PR TITLE
💄 Meilleure lisibilité des notes et des moyennes

### DIFF
--- a/html/assets/styles/releve-but.css
+++ b/html/assets/styles/releve-but.css
@@ -234,7 +234,6 @@ section>div:nth-child(1){
 .module, .ue {
     background: var(--couleurSecondaire);
     color: #000;
-    padding: 4px 32px;
     border-radius: 4px;
     display: flex;
 	align-items: center;
@@ -245,6 +244,17 @@ section>div:nth-child(1){
 	cursor: pointer;
 	position: relative;
 }
+
+.ue{
+    padding: 0.5em 1em 0.5em 2em;	
+}
+
+.module{
+    padding: 1em 2em;	
+}
+
+
+
 .module::before, .ue::before {
 	content:url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='26px' height='26px' fill='white'><path d='M7.41,8.58L12,13.17L16.59,8.58L18,10L12,16L6,10L7.41,8.58Z' /></svg>");
 	width: 26px;
@@ -288,10 +298,14 @@ h3{
     position: relative;
     display: flex;
     justify-content: space-between;
-    margin: 0 0 0 28px;
-    padding: 0px 4px;
+    padding: 0.5em;
     border-bottom: 1px solid #aaa;
 }
+
+.eval:nth-child(2n), .syntheseModule:nth-child(2n){
+    background: #ededed;
+}
+
 .eval>div, .syntheseModule>div{
 	display: flex;
 	gap: 4px;


### PR DESCRIPTION
Les notes et les moyennes peuvent être difficiles à lire en l'état actuel :

![image](https://user-images.githubusercontent.com/97701311/214140516-36aa6f81-72ff-4ba4-8021-a7f16687d8e2.png)

![image](https://user-images.githubusercontent.com/97701311/214141011-26199aba-d4a2-492a-a38a-abdb10b71a49.png)

De ce fait, j'ai :
- Ajouté plus d'espace aux titres et aux éléments
- Ajouté une alternance de couleur
- Retiré les marges à gauche

![image](https://user-images.githubusercontent.com/97701311/214139651-df7ae89b-35d9-4966-acba-a577dec880f6.png)

![image](https://user-images.githubusercontent.com/97701311/214139750-1be4c09d-f336-4f7e-99e3-36a6d1e77fc6.png)
