### PR TITLE
fix: full semester object passed instead of id

### DIFF
--- a/html/index.php
+++ b/html/index.php
@@ -241,7 +241,7 @@
 				} else {
 					document.querySelector("body").classList.add('etudiant');
 					feedSemesters(data.semestres);
-					showReportCards(data, data.semestres[0], data.auth.session);
+					showReportCards(data, data.semestres[0].formsemestre_id, data.auth.session);
 					feedAbsences(data.absences);
 				}
 			}


### PR DESCRIPTION
fixed a bug which caused the report cards url to contain [Object object]

please test before merging as I can't properly test it.

related to #116 