### PR TITLE
fix: duplication d'entrées des évaluations consultées

### DIFF
--- a/html/assets/js/releve-but.js
+++ b/html/assets/js/releve-but.js
@@ -482,6 +482,10 @@ class releveBUT extends HTMLElement {
 	addSeenEvaluation(el)
 	{
 		const seenEvaluations = this.getSeenEvaluations();
+		// Éviter les doublons
+		if(seenEvaluations.find((evaluation) => evaluation.id === el.dataset.id)){
+			return;
+		}
 		seenEvaluations.push({
 			id: el.dataset.id,
 			note: el.dataset.note


### PR DESCRIPTION
## Contexte

Lorsque l'on clique sur une évaluation, l'identifiant et la note sont stockés dans un tableau dans le localStorage afin de marquer l'évaluation comme "déjà consultée" par l'étudiant, supprimant ainsi le marqueur rose sur l'interface.

## Problème rencontré

Le problème avec le traitement actuel est qu'on ne vérifie pas si l'évaluation est déjà présente dans le tableau au moment du clic. Cela entraîne des doublons d'entrées.

## Solution apportée

J'ai donc ajouté une condition lors du clic sur l'évaluation pour vérifier si elle est déjà répertoriée.