### PR TITLE
Fix bouton semestre

### DIFF
--- a/html/index.php
+++ b/html/index.php
@@ -31,6 +31,7 @@
 			}
 			.semestres>label{
 				cursor: pointer;
+				margin: 8px;
 			}
 			.semestres input{
 				display: none;
@@ -38,7 +39,6 @@
 			.semestres>label>div{
 				background: var(--fond-clair);
 				padding: 8px 16px;
-				margin: 8px;
 				font-size: 18px;
 				text-align: right;
 				border-radius: 8px;


### PR DESCRIPTION
Correction du style du bouton semestre, qui était cliquable tout autour sur une étendu de 8 pixels, ce qui rendait le bouton actif, sans vraiment changer de semestre, en passant le ``margin: 8px`` de la div ``.semestres>label>div`` au label ``.semestres>label`` qui l'entoure.